### PR TITLE
Prevent Memory Leak by Reference Cycle

### DIFF
--- a/AppStoreInteractiveTransition/ViewControllers/CardDetailViewController.swift
+++ b/AppStoreInteractiveTransition/ViewControllers/CardDetailViewController.swift
@@ -158,7 +158,7 @@ class CardDetailViewController: StatusBarAnimatableViewController, UIScrollViewD
 
             if isDismissalSuccess {
                 dismissalAnimator!.stopAnimation(false)
-                dismissalAnimator!.addCompletion { (pos) in
+                dismissalAnimator!.addCompletion { [unowned self] (pos) in
                     switch pos {
                     case .end:
                         self.didSuccessfullyDragDownToDismiss()


### PR DESCRIPTION
I found a little mistake in the code, so I fixed it :) 

Currently, memory leak occur by strong reference on self

Appreciate for nice project.